### PR TITLE
Relative Import Behavior when stacked with import hooks

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -76,7 +76,7 @@ class _demandmod(object):
             # the right-most module instead of the left-most.
             fromlist = ['__name__'] if parent_path else []
             if level == -1:
-                mod = _origimport(path, globals, locals, fromlist)
+                mod = _origimport(path, globals, locals, fromlist, 0)
             else:
                 mod = _origimport(path, globals, locals, fromlist, level)
             assert not isinstance(mod, _demandmod)
@@ -125,7 +125,7 @@ def _demandimport(name, globals=None, locals=None, fromlist=None, level=-1):
         if not locals or name in _ignore or fromlist == ('*',):
             # these cases we can't really delay
             if level == -1:
-                return _origimport(name, globals, locals, fromlist)
+                return _origimport(name, globals, locals, fromlist, 0)
             else:
                 return _origimport(name, globals, locals, fromlist, level)
         elif not fromlist:


### PR DESCRIPTION
Had an issue when demandimport was used with a sys.meta_path import hook https://gist.github.com/fried/4254e881ba90cf0d9e4f26f7da3bcceb

The hook allows for the following:  (We have reasons for this, its not as simple as just forcing everyone to use one way or the other)
The module
 package.lib.module
can be imported with that name or the name
 package.module
but maintain that they are the same module object.    

Well when testing our hook with demandimport,  demandimport in python 2 was sending imports to our hook in the form  'package.lib.package' after we attempted to demand import 'package.lib.module'.      In python3 it worked as expected. 

I made the following change, and our tests passed and demain imports tests passed.   I know the level field controls absolute/relative imports in python2, and this might break some use case but i don't know what those could be. 
